### PR TITLE
add  /usr/local/share to backup file

### DIFF
--- a/source/system/backup_restore.rst
+++ b/source/system/backup_restore.rst
@@ -79,6 +79,7 @@ Here is the list of folders and files that are backed-up:
 * :file:`/root/.config/wazo-auth-cli/`
 * :file:`/usr/local/bin/`
 * :file:`/usr/local/sbin/`
+* :file:`/usr/local/share/`
 * :file:`/usr/share/wazo/WAZO-VERSION`
 * :file:`/var/lib/asterisk/`
 * :file:`/var/lib/consul/`


### PR DESCRIPTION
Currently custom certificates configured as shown in the doc are not backed up (see http://documentation.wazo.community/en/stable/system/https_certificate.html#use-your-own-certificate)